### PR TITLE
Predict and interpolate in one TF graph

### DIFF
--- a/kitti_predict.py
+++ b/kitti_predict.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
             raise NotImplementedError("TODO: iterate batches if > max_batch_size")
         timer["load_data"] += time.time() - start_time
 
-        # Predict
+        # Predict and interpolate
         start_time = time.time()
         dense_points = kitti_file_data.points
         dense_labels = predictor.predict_and_interpolate(
@@ -89,21 +89,6 @@ if __name__ == "__main__":
             sparse_points_batched=points,  # (batch_size, num_sparse_points, 3)
             dense_points=dense_points,  # (num_dense_points, 3)
         )
-
-        # pd_labels = predictor.predict(points_centered)
-        # points_collector.extend(points)
-        # pd_labels_collector.extend(pd_labels)
-        #
-        # points_collector = np.array(points_collector)
-        # pd_labels_collector = np.array(pd_labels_collector).astype(int)
-        #
-        # # Interpolate to original point cloud
-        # dense_points = kitti_file_data.points
-        # dense_labels = predictor.interpolate_labels(
-        #     sparse_points=points_collector.reshape((-1, 3)),
-        #     sparse_labels=pd_labels_collector.flatten(),
-        #     dense_points=dense_points.reshape((-1, 3)),
-        # )
         timer["predict_interpolate"] += time.time() - start_time
 
         # Save dense point cloud with predicted labels

--- a/kitti_predict.py
+++ b/kitti_predict.py
@@ -6,7 +6,7 @@ import open3d
 import time
 
 from dataset.kitti_dataset import KittiDataset
-from predict import Predictor
+from predict import PredictInterpolator
 
 
 def interpolate_dense_labels(sparse_points, sparse_labels, dense_points, k=3):
@@ -59,14 +59,14 @@ if __name__ == "__main__":
 
     # Model
     max_batch_size = 128  # The more the better, limited by memory size
-    predictor = Predictor(
+    predictor = PredictInterpolator(
         checkpoint_path=flags.ckpt,
         num_classes=dataset.num_classes,
         hyper_params=hyper_params,
     )
 
     for kitti_file_data in dataset.list_file_data[:5]:
-        timer = {"load_data": 0, "predict": 0, "interpolate": 0, "write_data": 0}
+        timer = {"load_data": 0, "predict_interpolate": 0, "write_data": 0}
 
         # Predict for num_samples times
         points_collector = []
@@ -83,23 +83,28 @@ if __name__ == "__main__":
 
         # Predict
         start_time = time.time()
-        pd_labels = predictor.predict(points_centered)
-        points_collector.extend(points)
-        pd_labels_collector.extend(pd_labels)
-        timer["predict"] += time.time() - start_time
-
-        points_collector = np.array(points_collector)
-        pd_labels_collector = np.array(pd_labels_collector).astype(int)
-
-        # Interpolate to original point cloud
-        start_time = time.time()
         dense_points = kitti_file_data.points
-        dense_labels = predictor.interpolate_labels(
-            sparse_points=points_collector.reshape((-1, 3)),
-            sparse_labels=pd_labels_collector.flatten(),
-            dense_points=dense_points.reshape((-1, 3)),
+        dense_labels = predictor.predict_and_interpolate(
+            sparse_points_centered_batched=points_centered,  # (batch_size, num_sparse_points, 3)
+            sparse_points_batched=points,  # (batch_size, num_sparse_points, 3)
+            dense_points=dense_points,  # (num_dense_points, 3)
         )
-        timer["interpolate"] += time.time() - start_time
+
+        # pd_labels = predictor.predict(points_centered)
+        # points_collector.extend(points)
+        # pd_labels_collector.extend(pd_labels)
+        #
+        # points_collector = np.array(points_collector)
+        # pd_labels_collector = np.array(pd_labels_collector).astype(int)
+        #
+        # # Interpolate to original point cloud
+        # dense_points = kitti_file_data.points
+        # dense_labels = predictor.interpolate_labels(
+        #     sparse_points=points_collector.reshape((-1, 3)),
+        #     sparse_labels=pd_labels_collector.flatten(),
+        #     dense_points=dense_points.reshape((-1, 3)),
+        # )
+        timer["predict_interpolate"] += time.time() - start_time
 
         # Save dense point cloud with predicted labels
         start_time = time.time()

--- a/kitti_predict.py
+++ b/kitti_predict.py
@@ -101,21 +101,10 @@ if __name__ == "__main__":
         )
         timer["interpolate"] += time.time() - start_time
 
+        # Save dense point cloud with predicted labels
         start_time = time.time()
-        # Save sparse point cloud with predicted labels
         file_prefix = os.path.basename(kitti_file_data.file_path_without_ext)
 
-        pcd = open3d.PointCloud()
-        pcd.points = open3d.Vector3dVector(points_collector.reshape((-1, 3)))
-        pcd_path = os.path.join(sparse_output_dir, file_prefix + ".pcd")
-        open3d.write_point_cloud(pcd_path, pcd)
-        print("Exported pcd to {}".format(pcd_path))
-
-        pd_labels_path = os.path.join(sparse_output_dir, file_prefix + ".labels")
-        np.savetxt(pd_labels_path, pd_labels_collector.flatten(), fmt="%d")
-        print("Exported labels to {}".format(pd_labels_path))
-
-        # Save dense point cloud with predicted labels
         dense_pcd = open3d.PointCloud()
         dense_pcd.points = open3d.Vector3dVector(dense_points.reshape((-1, 3)))
         dense_pcd_path = os.path.join(dense_output_dir, file_prefix + ".pcd")

--- a/predict.py
+++ b/predict.py
@@ -87,33 +87,6 @@ class PredictInterpolator:
         saver.restore(self.sess, checkpoint_path)
         print("Model restored")
 
-    # def predict(self, batch_data, run_metadata=None, run_options=None):
-    #     """
-    #     Args:
-    #         batch_data: batch_size * num_point * 6(3)
-    #
-    #     Returns:
-    #         pred_labels: batch_size * num_point * 1
-    #     """
-    #     is_training = False
-    #     feed_dict = {
-    #         self.ops["pl_points"]: batch_data,
-    #         self.ops["pl_is_training"]: is_training,
-    #     }
-    #     if run_metadata is None:
-    #         run_metadata = tf.RunMetadata()
-    #     if run_options is None:
-    #         run_options = tf.RunOptions()
-    #
-    #     pred_val = self.sess.run(
-    #         self.ops["pred"],
-    #         options=run_options,
-    #         run_metadata=run_metadata,
-    #         feed_dict=feed_dict,
-    #     )
-    #     pred_labels = np.argmax(pred_val, 2)  # batch_size * num_point
-    #     return pred_labels
-
     def predict_and_interpolate(
         self,
         sparse_points_centered_batched,
@@ -234,11 +207,6 @@ class Predictor:
             },
         )
         print("sess.run interpolate_labels time", time.time() - s)
-        # dense_labels_2 = interpolate_dense_labels_simple(
-        #     sparse_points, sparse_labels, dense_points, k=3
-        # )
-        # print("num_equal:", np.sum(dense_labels == dense_labels_2))
-        # print("num_not_equal:", np.sum(dense_labels != dense_labels_2))
         return dense_labels
 
 

--- a/predict.py
+++ b/predict.py
@@ -34,6 +34,117 @@ def interpolate_dense_labels_simple(sparse_points, sparse_labels, dense_points, 
     return dense_labels
 
 
+class PredictInterpolator:
+    def __init__(self, checkpoint_path, num_classes, hyper_params):
+        # Get ops from graph
+        with tf.device("/gpu:0"):
+            # Placeholders
+            pl_sparse_points_centered_batched, _, _ = model.get_placeholders(
+                hyper_params["num_point"], hyperparams=hyper_params
+            )
+            pl_is_training = tf.placeholder(tf.bool, shape=())
+
+            # Prediction
+            pred, _ = model.get_model(
+                pl_sparse_points_centered_batched,
+                pl_is_training,
+                num_classes,
+                hyperparams=hyper_params,
+            )
+            sparse_labels_batched = tf.argmax(pred, axis=2)
+            # (1, num_sparse_points) -> (num_sparse_points,)
+            sparse_labels = tf.reshape(sparse_labels_batched, [-1])
+            sparse_labels = tf.cast(sparse_labels, tf.int32)
+
+            # Saver
+            saver = tf.train.Saver()
+
+            # Graph for interpolating labels
+            # Assuming batch_size == 1 for simplicity
+            pl_sparse_points_batched = tf.placeholder(tf.float32, (None, None, 3))
+            sparse_points = tf.reshape(pl_sparse_points_batched, [-1, 3])
+            pl_dense_points = tf.placeholder(tf.float32, (None, 3))
+            pl_knn = tf.placeholder(tf.int32, ())
+            dense_labels = interpolate_label(
+                sparse_points, sparse_labels, pl_dense_points, pl_knn
+            )
+
+        self.ops = {
+            "pl_sparse_points_centered_batched": pl_sparse_points_centered_batched,
+            "pl_sparse_points_batched": pl_sparse_points_batched,
+            "pl_dense_points": pl_dense_points,
+            "pl_is_training": pl_is_training,
+            "pl_knn": pl_knn,
+            "dense_labels": dense_labels,
+        }
+
+        # Restore checkpoint to session
+        config = tf.ConfigProto()
+        config.gpu_options.allow_growth = True
+        config.allow_soft_placement = True
+        config.log_device_placement = False
+        self.sess = tf.Session(config=config)
+        saver.restore(self.sess, checkpoint_path)
+        print("Model restored")
+
+    # def predict(self, batch_data, run_metadata=None, run_options=None):
+    #     """
+    #     Args:
+    #         batch_data: batch_size * num_point * 6(3)
+    #
+    #     Returns:
+    #         pred_labels: batch_size * num_point * 1
+    #     """
+    #     is_training = False
+    #     feed_dict = {
+    #         self.ops["pl_points"]: batch_data,
+    #         self.ops["pl_is_training"]: is_training,
+    #     }
+    #     if run_metadata is None:
+    #         run_metadata = tf.RunMetadata()
+    #     if run_options is None:
+    #         run_options = tf.RunOptions()
+    #
+    #     pred_val = self.sess.run(
+    #         self.ops["pred"],
+    #         options=run_options,
+    #         run_metadata=run_metadata,
+    #         feed_dict=feed_dict,
+    #     )
+    #     pred_labels = np.argmax(pred_val, 2)  # batch_size * num_point
+    #     return pred_labels
+
+    def predict_and_interpolate(
+        self,
+        sparse_points_centered_batched,
+        sparse_points_batched,
+        dense_points,
+        run_metadata=None,
+        run_options=None,
+    ):
+        s = time.time()
+        if run_metadata is None:
+            run_metadata = tf.RunMetadata()
+        if run_options is None:
+            run_options = tf.RunOptions()
+        dense_labels_val = self.sess.run(
+            self.ops["dense_labels"],
+            feed_dict={
+                self.ops[
+                    "pl_sparse_points_centered_batched"
+                ]: sparse_points_centered_batched,
+                self.ops["pl_sparse_points_batched"]: sparse_points_batched,
+                self.ops["pl_dense_points"]: dense_points,
+                self.ops["pl_knn"]: 3,
+                self.ops["pl_is_training"]: False,
+            },
+            options=run_options,
+            run_metadata=run_metadata,
+        )
+        print("sess.run interpolate_labels time", time.time() - s)
+        return dense_labels_val
+
+
 class Predictor:
     def __init__(self, checkpoint_path, num_classes, hyper_params):
         # Get ops from graph

--- a/tf_ops/tf_interpolate.cpp
+++ b/tf_ops/tf_interpolate.cpp
@@ -194,62 +194,32 @@ REGISTER_OP("ThreeNN")
 //   base_points, the "3" means "3" nearest neighbors
 void threenn_cpu(int b, int n, int m, const float *xyz1, const float *xyz2,
                  float *dists, int *indices) {
-    if (b == 1) {
-        open3d::PointCloud reference_pcd;
-
-        reference_pcd.points_ = buffer_to_eigen_vector(xyz2, m * 3);
-        open3d::KDTreeFlann reference_kd_tree(reference_pcd);
-
-        // #ifdef _OPENMP
-        // #pragma omp parallel for schedule(static)
-        // #endif
-        // Move vectors inside if using omp, outside if omp disabled
+    // OPENMP only sees benefits if b is large, e.g. b == 64
+    // #ifdef _OPENMP
+    // #pragma omp parallel for schedule(static)
+    // #endif
+    for (int batch_index = 0; batch_index < b; ++batch_index) {
         std::vector<int> three_indices;
         std::vector<double> three_dists;
-        Eigen::Vector3d target_point;
+        open3d::PointCloud target_pcd;
+        open3d::PointCloud reference_pcd;
+
+        target_pcd.points_ =
+            buffer_to_eigen_vector(xyz1 + batch_index * n * 3, n * 3);
+        reference_pcd.points_ =
+            buffer_to_eigen_vector(xyz2 + batch_index * m * 3, m * 3);
+        open3d::KDTreeFlann reference_kd_tree(reference_pcd);
+
         for (size_t j = 0; j < n; ++j) {
-            size_t target_point_idx = j * 3;
-            target_point(0) = xyz1[target_point_idx];
-            target_point(1) = xyz1[target_point_idx + 1];
-            target_point(2) = xyz1[target_point_idx + 2];
-            reference_kd_tree.SearchKNN(target_point, 3, three_indices,
+            reference_kd_tree.SearchKNN(target_pcd.points_[j], 3, three_indices,
                                         three_dists);
-            size_t start_idx = j * 3;
+            size_t start_idx = batch_index * n * 3 + j * 3;
             indices[start_idx + 0] = three_indices[0];
             indices[start_idx + 1] = three_indices[1];
             indices[start_idx + 2] = three_indices[2];
             dists[start_idx + 0] = three_dists[0];
             dists[start_idx + 1] = three_dists[1];
             dists[start_idx + 2] = three_dists[2];
-        }
-    } else {
-        // OPENMP only sees benefits if b is large, e.g. b == 64
-        // #ifdef _OPENMP
-        // #pragma omp parallel for schedule(static)
-        // #endif
-        for (int batch_index = 0; batch_index < b; ++batch_index) {
-            std::vector<int> three_indices;
-            std::vector<double> three_dists;
-            open3d::PointCloud target_pcd;
-            open3d::PointCloud reference_pcd;
-
-            target_pcd.points_ =
-                buffer_to_eigen_vector(xyz1 + batch_index * n * 3, n * 3);
-            reference_pcd.points_ =
-                buffer_to_eigen_vector(xyz2 + batch_index * m * 3, m * 3);
-            open3d::KDTreeFlann reference_kd_tree(reference_pcd);
-
-            for (size_t j = 0; j < n; ++j) {
-                reference_kd_tree.SearchKNN(target_pcd.points_[j], 3,
-                                            three_indices, three_dists);
-                size_t start_idx = batch_index * n * 3 + j * 3;
-                indices[start_idx + 0] = three_indices[0];
-                indices[start_idx + 1] = three_indices[1];
-                indices[start_idx + 2] = three_indices[2];
-                dists[start_idx + 0] = three_dists[0];
-                dists[start_idx + 1] = three_dists[1];
-                dists[start_idx + 2] = three_dists[2];
-            }
         }
     }
 }


### PR DESCRIPTION
Since label interpolation is implemented as a TF op, we could put predict and interpolate inside one TF graph.

### before
```
'load_data': 0.009927988052368164, 
'predict': 0.04781484603881836,
'interpolate': 0.0362849235534668,
'write_data': 0.2045590877532959
```

### after
```
'load_data': 0.010023355484008789,
'predict_interpolate': 0.07775688171386719,
'write_data': 0.20769476890563965
```